### PR TITLE
Use the same token and cookie values as the headers example

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -28,5 +28,8 @@ The value in the `csrftoken` cookie needs to be passed in an `X-Csrf-Token` HTTP
 A login request, for example, would look like this:
 
 ```bash
-curl 'http://discuit.net/api/_login' -XPOST -H 'Cookie: SID=aVVdZDQLCaDUFnMEwKwpbzwoNVnytESJNRVI' -H 'X-Csrf-Token: ciSk6IDY7rQ1pHu9yueb2TXUjJQU8r1pKjisA3S7Px0=' -d '{"username":"neo","password":"whatever"}'
+curl 'http://discuit.net/api/_login' -XPOST \
+-H 'Cookie: SID=GyzghHpzr3vOdUG2pOoEeqRBFKwbVWBw5Ovy' \
+-H 'X-Csrf-Token: FcVgW9FZD8w3iptTeh-Nm3cWm4QjVXYulKjqMWjSJkg=' \
+-d '{"username":"neo","password":"whatever"}'
 ```


### PR DESCRIPTION
Closes #13 