### PR TITLE
Add `<link rel="icon">` tag to `<head>`

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
   description: "The documentation for Discuit's API",
   lang: "en-US",
   cleanUrls: true,
+  head: [["link", { rel: "icon", href: "/favicon.png" }]],
   themeConfig: {
     // https://vitepress.dev/reference/default-theme-config
     logo: "/favicon.png",


### PR DESCRIPTION
This should force browsers like Chrome and Firefox to load the favicon properly.