### PR TITLE
Clarify Community List Endpoint

### DIFF
--- a/docs/endpoints/communities/communities.md
+++ b/docs/endpoints/communities/communities.md
@@ -2,11 +2,11 @@
 
 ## GET
 
+Returns an array of Community objects.
+
 ::: info
 This endpoint provides a summary view of Community objects, ideal for listing multiple communities such as on a homepage or in search results. Detailed attributes like moderators, rules, and report details may be omitted in this summary view.
 :::
-
-Returns an array of Community objects.
 
 ### Query parameters
 

--- a/docs/endpoints/communities/communities.md
+++ b/docs/endpoints/communities/communities.md
@@ -14,3 +14,7 @@ Returns an array of Community objects.
 The query parameter `set=all` returns all communities available. And `default` returns the list of default communities, and `subscribed` returns the list of communities the authenticated user is a member of.
 
 If `q=` is set, a matching set of communities is returned.
+
+### More information
+
+This endpoint provides a summary view of Community objects, ideal for listing multiple communities such as on a homepage or in search results. Detailed attributes like moderators, rules, and report details may be omitted in this summary view.

--- a/docs/endpoints/communities/communities.md
+++ b/docs/endpoints/communities/communities.md
@@ -2,6 +2,10 @@
 
 ## GET
 
+::: info
+This endpoint provides a summary view of Community objects, ideal for listing multiple communities such as on a homepage or in search results. Detailed attributes like moderators, rules, and report details may be omitted in this summary view.
+:::
+
 Returns an array of Community objects.
 
 ### Query parameters
@@ -14,7 +18,3 @@ Returns an array of Community objects.
 The query parameter `set=all` returns all communities available. And `default` returns the list of default communities, and `subscribed` returns the list of communities the authenticated user is a member of.
 
 If `q=` is set, a matching set of communities is returned.
-
-### More information
-
-This endpoint provides a summary view of Community objects, ideal for listing multiple communities such as on a homepage or in search results. Detailed attributes like moderators, rules, and report details may be omitted in this summary view.


### PR DESCRIPTION
This PR introduces an updates to the API documentation to clarify the data returned and purpose of the /api/communities endpoint.

clarify page for #4 
cc (@noClaps)